### PR TITLE
:bug: Fix `config.example.ini` Memcache's configuration

### DIFF
--- a/config.example.ini
+++ b/config.example.ini
@@ -6,9 +6,10 @@ APPLICATION_NAME = PhpShell
 baseUrl = /
 protocol = http
 
+; Memcache servers, default vaue is for docker setup
 [Memcache.servers]
-localhost[host] = 127.0.0.1
-localhost[port] = 11211
+memcached[host] = memcached
+memcached[port] = 11211
 
 ;[Session]
 ; disabled so fastcgi_cache can cache globally, we must only set cookies for logged in users!
@@ -28,8 +29,3 @@ sourcePath = APPLICATION_PATH/tpl/
 source[superglobal] = REQUEST
 source[key] = 0
 default = index
-
-; Memcache servers, default vaue is for docker setup
-[Memcache.servers]
-memcached[host] = memcached
-memcached[port] = 11211


### PR DESCRIPTION
The property was declared twice so 2 memcache servers were required. Use the docker instance by default.