### PR TITLE
Add persistent keybindings option

### DIFF
--- a/htdocs/s/my.css
+++ b/htdocs/s/my.css
@@ -249,6 +249,14 @@ body.touch dd
 	margin-left: 15px;
 }
 
+#prefs select {
+	margin-left: 15px;
+	margin-right: 2px;
+	width: auto;
+	height: auto;
+	padding: 0px 4px;
+}
+
 form.submit-attempted textarea.invalid,
 form.submit-attempted code.invalid,
 form.submit-attempted input.invalid

--- a/htdocs/s/my.js
+++ b/htdocs/s/my.js
@@ -95,6 +95,12 @@ var evalOrg = {};
 		}
 	};
 
+	this.applyKeybindings = function(keybindings)
+	{
+		if (this.editor)
+			this.editor.setKeyboardHandler('ace/keyboard/' + keybindings);
+	};
+
 	this.applyPrefs = function()
 	{
 		var defaul = false;
@@ -115,6 +121,15 @@ var evalOrg = {};
 			this.applyDarkmode(e.target.checked)
 		}.bind(this));
 
+		var keybindings = localStorage.getItem('keybindings');
+		if (keybindings) {
+			this.applyKeybindings(keybindings);
+			$('#keybindings').value = keybindings;
+		}
+		$('#keybindings').addEventListener('change', function (e) {
+			localStorage.setItem('keybindings', e.target.value);
+			this.applyKeybindings(e.target.value);
+		}.bind(this));
 
 		if (localStorage.getItem("livePreview") !== "disable")
 			$('#livePreview').setAttribute('checked', 'checked');
@@ -151,6 +166,8 @@ var evalOrg = {};
 			this.editor.setTheme('ace/theme/chaos');
 		else
 			this.editor.setTheme('ace/theme/chrome');
+
+		this.applyKeybindings(localStorage.getItem("keybindings"));
 
 		this.editor.setShowPrintMargin(false);
 		this.editor.setOption('maxLines', Infinity);

--- a/htdocs/s/my.js
+++ b/htdocs/s/my.js
@@ -97,8 +97,9 @@ var evalOrg = {};
 
 	this.applyKeybindings = function(keybindings)
 	{
-		if (this.editor)
-			this.editor.setKeyboardHandler('ace/keyboard/' + keybindings);
+		if (this.editor) {
+			this.editor.setKeyboardHandler(keybindings === 'ace' ? null : 'ace/keyboard/' + keybindings);
+		}
 	};
 
 	this.applyPrefs = function()

--- a/htdocs/s/my.js
+++ b/htdocs/s/my.js
@@ -98,7 +98,9 @@ var evalOrg = {};
 	this.applyKeybindings = function(keybindings)
 	{
 		if (this.editor) {
-			this.editor.setKeyboardHandler(keybindings === 'ace' ? null : 'ace/keyboard/' + keybindings);
+			this.editor.setKeyboardHandler(!keybindings || keybindings === 'ace'
+				? null
+				: 'ace/keyboard/' + keybindings);
 		}
 	};
 

--- a/tpl/footer.html
+++ b/tpl/footer.html
@@ -4,6 +4,12 @@
 		preferences:
 		<input type="checkbox" id="darkMode" /><label for="darkMode">dark mode</label>
 		<input type="checkbox" id="livePreview" /><label for="livePreview">live preview</label>
+		<select id="keybindings">
+			<option value="ace">ace</option>
+			<option value="vim">vim</option>
+			<option value="emacs">emacs</option>
+		</select>
+		<label for="keybindings">key bindings</label>
 	</div>
 
 	{$statistics = Basic::$log->getStatistics();}


### PR DESCRIPTION
I also considered storing the entire `getOptions()` value after tweaking the built-in settings with `ctrl+,`. However, that settings panel contains many settings that can't be changed, or ones that shouldn't be. So, a more "native" option seemed better.