### PR TITLE
my.css Add padding to the `textarea` field for mobile devices

### DIFF
--- a/htdocs/s/my.css
+++ b/htdocs/s/my.css
@@ -223,6 +223,8 @@ html.darkMode body.js code:not(.ace_editor)
 textarea[name=code]
 {
 	display: none;
+	padding: 10px;
+	box-sizing: border-box;
 }
 
 body.mobile textarea,


### PR DESCRIPTION
Add padding to the TEXTAREA field, please, because on smartphones you have to work hard to place the cursor at the beginning of the line, especially on devices with curved screens such as the Xiaomi 12X