### PR TITLE
:sparkles: upgrade php-wasm, support mbstring extension, compute version dynamically

### DIFF
--- a/htdocs/s/my.js
+++ b/htdocs/s/my.js
@@ -227,40 +227,45 @@ var evalOrg = {};
 			}
 		}));
 
+		const PHP_VERSION = '8.4';
 		$('#tab').appendChild(object2Dom({
 			dl:{
-				dt: {_text: "Output for php 8.2.11"},
+				dt: {_text: "Output for php " + PHP_VERSION},
 				dd: {
 					div: {
 						id: 'live_preview'
 		}	}	}	}));
 
 		import('https://cdn.jsdelivr.net/npm/php-wasm/PhpWeb.mjs')
-			.then( imported => this.livePreviewInit(imported));
+			.then( imported => this.livePreviewInit(imported, PHP_VERSION));
 
 		// subsequent updates are handled by editor.on('change')
 	};
 
-	this.livePreviewInit = function(imported){
+	this.livePreviewInit = async function(imported, version){
 		const { PhpWeb } = imported;
-		this.php = new PhpWeb({ini: `
-max_execution_time = 3
-memory_limit = 64M
-enable_dl = Off
-
-; for consistency of older versions
-allow_call_time_pass_reference = Off
-html_errors = Off
-
-; show all errors by default, if we'd lower this in the script we'll miss some parser notices
-error_reporting = -1
-display_errors = On
-display_startup_errors = On
-log_errors = Off
-report_memleaks = On
-
-[Date]
-date.timezone = Europe/Amsterdam`});
+		this.php = new PhpWeb({
+			version,
+			ini: [
+				'max_execution_time = 3',
+				'memory_limit = 64M',
+				'enable_dl = Off',
+				// for consistency of older versions
+				'allow_call_time_pass_reference = Off',
+				'html_errors = Off',
+				// show all errors by default, if we'd lower this in the script we'll miss some parser notices
+				'error_reporting = -1',
+				'display_errors = On',
+				'display_startup_errors = On',
+				'log_errors = Off',
+				'report_memleaks = On',
+				// Date
+				'date.timezone = Europe/Amsterdam',
+			].join('\n'),
+			sharedLibs: [
+				await import(`https://cdn.jsdelivr.net/npm/php-wasm-mbstring/${version}.mjs`),
+			]
+		});
 
 		this.php.addEventListener('output', (event) => {
 			if ($('#live_preview')) // this should not happen - but it does


### PR DESCRIPTION
### Upgrade `php-wasm`

There were a lot of alpha releases, the 0.1.0 was just released. Upgrading is required for `sharedLibs` support.

### Add `mbstring` extension

In today's world most code should support UTF-8, mbstring is almost mandatory for this. Hence supporting it in live preview should help testing some snippets. php-wasm allow loading extensions https://github.com/seanmorris/php-wasm/issues/101.

### compute version dynamically

Supersedes #16 as I had to upgrade `php-wasm`. Having it dynamically computed ensure it stays aligned when we upgrade `php-wasm`. We can pass the phpversion we want directly to phpwasm.

~~Note that I displayed `phpVersionFull` (which is `8.3.11` here) instead of `phpVersion` (which is `8.3` here)~~

### Load size

Without cache, opening the page and loading the live preview loads 17.48MB of data (4.29MB transferred). In particular mbstring accounts for 1.7MB (650kB transferred).

With the cache we load 17.48MB of data, but only 330kB is transferred thanks to CDN cache.

### Test

Note that I used and upgraded my docker branch under #15.

Note that there are some requests failing in local because it tries to load 3v4l.org resources which are denied in local:
https://github.com/SjonHortensius/3v4l_org/blob/0e39cfc95ccb7c67db8246a8afc8bfb33e1d94f8/library/PhpShell/Action.php#L24
Changing this row with the following allowed most of the resources to load (some are still failing)
```diff
-'connect-src' => ["'self'", "https://cdn.jsdelivr.net/"], # for xhr | php-wasm
+'connect-src' => ["'self'", "https://cdn.jsdelivr.net/", "https://3v4l.org"], # for xhr | php-wasm
```