### PR TITLE
:bug: Fix PhpWeb.mjs preload link, preload all resources

### DIFF
--- a/htdocs/s/my.js
+++ b/htdocs/s/my.js
@@ -236,7 +236,7 @@ var evalOrg = {};
 						id: 'live_preview'
 		}	}	}	}));
 
-		import('https://cdn.jsdelivr.net/npm/php-wasm/PhpWeb.mjs')
+		import('https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/PhpWeb.mjs')
 			.then( imported => this.livePreviewInit(imported, PHP_VERSION));
 
 		// subsequent updates are handled by editor.on('change')
@@ -263,7 +263,7 @@ var evalOrg = {};
 				'date.timezone = Europe/Amsterdam',
 			].join('\n'),
 			sharedLibs: [
-				await import(`https://cdn.jsdelivr.net/npm/php-wasm-mbstring/${version}.mjs`),
+				await import(`https://cdn.jsdelivr.net/npm/php-wasm-mbstring@0.1.0/${version}.mjs`),
 			]
 		});
 

--- a/library/PhpShell/Action.php
+++ b/library/PhpShell/Action.php
@@ -32,9 +32,19 @@ class PhpShell_Action extends Basic_Action
 	];
 	public $httpPreloads = [
 			'/s/my.js' => 'preload',
-			'https://cdn.jsdelivr.net/npm/php-wasm/PhpBase.mjs' => 'modulepreload',
-			'https://cdn.jsdelivr.net/npm/php-wasm/php-web.mjs' => 'modulepreload',
-#			'https://cdn.jsdelivr.net/npm/php-wasm/php-web.mjs.wasm' => 'modulepreload', # Loading module from “https://cdn.jsdelivr.net/npm/php-wasm/php-web.mjs.wasm” was blocked because of a disallowed MIME type (“application/wasm”).
+			'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/PhpWeb.mjs' => 'modulepreload',
+            // Load the biggest file earlier (only this wasm is out of order)
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/e31ec3faf3e2323a2b4a448342b50307765b8217.wasm' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/PhpBase.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/webTransactions.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/OutputBuffer.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/_Event.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/fsOps.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/resolveDependencies.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm@0.1.0/php8.4-web.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm-mbstring@0.1.0/8.4.mjs' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm-mbstring@0.1.0/php8.4-mbstring.so' => 'modulepreload',
+            'https://cdn.jsdelivr.net/npm/php-wasm-mbstring@0.1.0/libonig.so' => 'modulepreload',
 	];
 	public $aceScripts = [
 		// curl -s URL | openssl dgst -sha384 -binary | openssl base64 -A


### PR DESCRIPTION
Noticed a HTTP 404 when testing #55 (thanks for merging it).

Note that this is not the only module which is required to load the wasm interpreter. The list of URLs I observe when I start inputting something in the box is:
1. https://cdn.jsdelivr.net/npm/php-wasm/PhpWeb.mjs
2. https://cdn.jsdelivr.net/npm/php-wasm/webTransactions.mjs
3. https://cdn.jsdelivr.net/npm/php-wasm-mbstring/8.4.mjs
4. https://cdn.jsdelivr.net/npm/php-wasm/php8.4-web.mjs
5. https://cdn.jsdelivr.net/npm/php-wasm/e31ec3faf3e2323a2b4a448342b50307765b8217.wasm
6. https://cdn.jsdelivr.net/npm/php-wasm-mbstring/php8.4-mbstring.so
7. https://cdn.jsdelivr.net/npm/php-wasm-mbstring/libonig.so

Should I include them ? There is a comment about wasm not being possible to preload, and it is the biggest offender (13.83MB), so maybe we should not preload anything ?